### PR TITLE
support setRotation() for 0, 2

### DIFF
--- a/Adafruit_RA8875.cpp
+++ b/Adafruit_RA8875.cpp
@@ -301,6 +301,13 @@ void Adafruit_RA8875::textMode(void)
 /**************************************************************************/
 void Adafruit_RA8875::textSetCursor(uint16_t x, uint16_t y) 
 {
+  switch(rotation) {
+      case 2:
+          x = WIDTH  - 1 - x;
+          y = HEIGHT - 1 - y;
+          break;
+  }
+
   /* Set cursor location */
   writeCommand(0x2A);
   writeData(x & 0xFF);
@@ -507,6 +514,13 @@ void Adafruit_RA8875::fillRect(void) {
 /**************************************************************************/
 void Adafruit_RA8875::drawPixel(int16_t x, int16_t y, uint16_t color)
 {
+  switch(rotation) {
+      case 2:
+          x = WIDTH  - 1 - x;
+          y = HEIGHT - 1 - y;
+          break;
+  }
+
   writeReg(RA8875_CURH0, x);
   writeReg(RA8875_CURH1, x >> 8);
   writeReg(RA8875_CURV0, y);
@@ -532,6 +546,15 @@ void Adafruit_RA8875::drawPixel(int16_t x, int16_t y, uint16_t color)
 /**************************************************************************/
 void Adafruit_RA8875::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color)
 {
+  switch(rotation) {
+      case 2:
+          x0 = WIDTH  - 1 - x0;
+          y0 = HEIGHT - 1 - y0;
+          x1 = WIDTH  - 1 - x1;
+          y1 = HEIGHT - 1 - y1;
+          break;
+  }
+
   /* Set X */
   writeCommand(0x91);
   writeData(x0);
@@ -783,6 +806,13 @@ void Adafruit_RA8875::fillCurve(int16_t xCenter, int16_t yCenter, int16_t longAx
 /**************************************************************************/
 void Adafruit_RA8875::circleHelper(int16_t x0, int16_t y0, int16_t r, uint16_t color, bool filled)
 {
+  switch(rotation) {
+      case 2:
+          x0 = WIDTH  - 1 - x0;
+          y0 = HEIGHT - 1 - y0;
+          break;
+  }
+
   /* Set X */
   writeCommand(0x99);
   writeData(x0);
@@ -827,31 +857,40 @@ void Adafruit_RA8875::circleHelper(int16_t x0, int16_t y0, int16_t r, uint16_t c
       Helper function for higher level rectangle drawing code
 */
 /**************************************************************************/
-void Adafruit_RA8875::rectHelper(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color, bool filled)
+void Adafruit_RA8875::rectHelper(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color, bool filled)
 {
+  switch(rotation) {
+      case 2:
+          x0 = WIDTH  - 1 - x0;
+          y0 = HEIGHT - 1 - y0;
+          x1 = WIDTH  - 1 - x1;
+          y1 = HEIGHT - 1 - y1;
+          break;
+  }
+
   /* Set X */
   writeCommand(0x91);
-  writeData(x);
+  writeData(x0);
   writeCommand(0x92);
-  writeData(x >> 8);
+  writeData(x0 >> 8);
   
   /* Set Y */
   writeCommand(0x93);
-  writeData(y); 
+  writeData(y0); 
   writeCommand(0x94);	   
-  writeData(y >> 8);
+  writeData(y0 >> 8);
   
   /* Set X1 */
   writeCommand(0x95);
-  writeData(w);
+  writeData(x1);
   writeCommand(0x96);
-  writeData((w) >> 8);
+  writeData((x1) >> 8);
   
   /* Set Y1 */
   writeCommand(0x97);
-  writeData(h); 
+  writeData(y1); 
   writeCommand(0x98);
-  writeData((h) >> 8);
+  writeData((y1) >> 8);
 
   /* Set Color */
   writeCommand(0x63);
@@ -883,6 +922,17 @@ void Adafruit_RA8875::rectHelper(int16_t x, int16_t y, int16_t w, int16_t h, uin
 /**************************************************************************/
 void Adafruit_RA8875::triangleHelper(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color, bool filled)
 {
+  switch(rotation) {
+      case 2:
+          x0 = WIDTH  - 1 - x0;
+          y0 = HEIGHT - 1 - y0;
+          x1 = WIDTH  - 1 - x1;
+          y1 = HEIGHT - 1 - y1;
+          x2 = WIDTH  - 1 - x2;
+          y2 = HEIGHT - 1 - y2;
+          break;
+  }
+
   /* Set Point 0 */
   writeCommand(0x91);
   writeData(x0);
@@ -943,6 +993,13 @@ void Adafruit_RA8875::triangleHelper(int16_t x0, int16_t y0, int16_t x1, int16_t
 /**************************************************************************/
 void Adafruit_RA8875::ellipseHelper(int16_t xCenter, int16_t yCenter, int16_t longAxis, int16_t shortAxis, uint16_t color, bool filled)
 {
+  switch(rotation) {
+      case 2:
+          xCenter = WIDTH  - 1 - xCenter;
+          yCenter = HEIGHT - 1 - yCenter;
+          break;
+  }
+
   /* Set Center Point */
   writeCommand(0xA5);
   writeData(xCenter);
@@ -993,6 +1050,13 @@ void Adafruit_RA8875::ellipseHelper(int16_t xCenter, int16_t yCenter, int16_t lo
 /**************************************************************************/
 void Adafruit_RA8875::curveHelper(int16_t xCenter, int16_t yCenter, int16_t longAxis, int16_t shortAxis, uint8_t curvePart, uint16_t color, bool filled)
 {
+  switch(rotation) {
+      case 2:
+          xCenter = WIDTH  - 1 - xCenter;
+          yCenter = HEIGHT - 1 - yCenter;
+          break;
+  }
+
   /* Set Center Point */
   writeCommand(0xA5);
   writeData(xCenter);


### PR DESCRIPTION
Support setRotation from parent GFX library for rotation = 2 (invert). Ignores rotations 1 and 3. Also fix argument naming in rectHelper - w and h are really the x,y coords of the opposite corner.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
