### PR TITLE
Added drawPixels() function for much faster BMP drawing

### DIFF
--- a/Adafruit_RA8875.cpp
+++ b/Adafruit_RA8875.cpp
@@ -521,6 +521,33 @@ void Adafruit_RA8875::drawPixel(int16_t x, int16_t y, uint16_t color)
 
 /**************************************************************************/
 /*!
+ Draws a series of pixels at the specified location without the overhead
+ 
+ @args p[in]     An array of RGB565 color pixels
+ @args num[in]   The number of the pixels to draw
+ @args x[in]     The 0-based x location
+ @args y[in]     The 0-base y location
+ */
+/**************************************************************************/
+void Adafruit_RA8875::drawPixels(uint16_t * p, uint32_t num, int16_t x, int16_t y)
+{
+    writeReg(RA8875_CURH0, x);
+    writeReg(RA8875_CURH1, x >> 8);
+    writeReg(RA8875_CURV0, y);
+    writeReg(RA8875_CURV1, y >> 8);
+    writeCommand(RA8875_MRWC);
+    digitalWrite(_cs, LOW);
+    SPI.transfer(RA8875_DATAWRITE);
+    while (num--) {
+        SPI.transfer(*p >> 8);
+        SPI.transfer(*p & 0xFF);
+        p++;
+    }
+    digitalWrite(_cs, HIGH);
+}
+
+/**************************************************************************/
+/*!
       Draws a HW accelerated line on the display
     
       @args x0[in]    The 0-based starting x location

--- a/Adafruit_RA8875.h
+++ b/Adafruit_RA8875.h
@@ -88,6 +88,7 @@ class Adafruit_RA8875 : public Adafruit_GFX {
 
   /* Adafruit_GFX functions */
   void    drawPixel(int16_t x, int16_t y, uint16_t color);
+  void    drawPixels(uint16_t * p, uint32_t count, int16_t x, int16_t y);
   void    drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
   void    drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
   

--- a/examples/ra8875_bitmap_fast/ra8875_bitmap_fast.ino
+++ b/examples/ra8875_bitmap_fast/ra8875_bitmap_fast.ino
@@ -1,0 +1,232 @@
+#include <Adafruit_GFX.h>    // Core graphics library
+#include <SPI.h>
+#include <Wire.h>   
+#include <SD.h>
+#include "Adafruit_RA8875.h"
+#include <Adafruit_STMPE610.h>
+#define sd_cs 6                          // using ethernet shield sd
+
+// Library only supports hardware SPI at this time
+// Connect SCLK to UNO Digital #13 (Hardware SPI clock)
+// Connect MISO to UNO Digital #12 (Hardware SPI MISO)
+// Connect MOSI to UNO Digital #11 (Hardware SPI MOSI)
+#define RA8875_INT 3
+#define RA8875_CS 10
+#define RA8875_RESET 9
+
+Adafruit_RA8875 tft = Adafruit_RA8875(RA8875_CS, RA8875_RESET);
+
+void setup () {
+  Serial.begin(9600);
+
+  if (!SD.begin(sd_cs)) 
+  {
+    Serial.println("initialization failed!");
+    return;
+  }
+
+  Serial.println("initialization done.");
+
+  Serial.println("RA8875 start");
+
+  /* Initialise the display using 'RA8875_480x272' or 'RA8875_800x480' */
+  if (!tft.begin(RA8875_800x480)) {
+    Serial.println("RA8875 Not Found!");
+    while (1);
+  }
+
+  Serial.println("Found RA8875");
+
+  tft.displayOn(true);
+  tft.GPIOX(true);      // Enable TFT - display enable tied to GPIOX
+  tft.PWM1config(true, RA8875_PWM_CLK_DIV1024); // PWM output for backlight
+  tft.PWM1out(255);
+
+  Serial.print("("); 
+  Serial.print(tft.width());
+  Serial.print(", "); 
+  Serial.print(tft.height());
+  Serial.println(")");
+  tft.graphicsMode();                 // go back to graphics mode
+  tft.fillScreen(RA8875_BLACK);
+  tft.graphicsMode();     
+  bmpDraw("parrot.bmp", 0, 0);
+}
+
+void loop()
+{
+}    
+
+// This function opens a Windows Bitmap (BMP) file and
+// displays it at the given coordinates.  It's sped up
+// by reading many pixels worth of data at a time
+// (rather than pixel by pixel).  Increasing the buffer
+// size takes more of the Arduino's precious RAM but
+// makes loading a little faster.  20 pixels seems a
+// good balance.
+
+#define BUFFPIXEL 20
+
+void bmpDraw(char *filename, int x, int y) {
+  File     bmpFile;
+  int      bmpWidth, bmpHeight;   // W+H in pixels
+  uint8_t  bmpDepth;              // Bit depth (currently must be 24)
+  uint32_t bmpImageoffset;        // Start of image data in file
+  uint32_t rowSize;               // Not always = bmpWidth; may have padding
+  uint8_t  sdbuffer[3*BUFFPIXEL]; // pixel in buffer (R+G+B per pixel)
+  uint16_t lcdbuffer[BUFFPIXEL];  // pixel out buffer (16-bit per pixel)
+  uint8_t  buffidx = sizeof(sdbuffer); // Current position in sdbuffer
+  boolean  goodBmp = false;       // Set to true on valid header parse
+  boolean  flip    = true;        // BMP is stored bottom-to-top
+  int      w, h, row, col;
+  uint8_t  r, g, b;
+  uint32_t pos = 0, startTime = millis();
+  uint8_t  lcdidx = 0;
+  boolean  first = true;
+
+  if((x >= tft.width()) || (y >= tft.height())) return;
+
+  Serial.println();
+  Serial.print(F("Loading image '"));
+  Serial.print(filename);
+  Serial.println('\'');
+
+  // Open requested file on SD card
+  if ((bmpFile = SD.open(filename)) == NULL) {
+    Serial.println(F("File not found"));
+    return;
+  }
+
+  // Parse BMP header
+  if(read16(bmpFile) == 0x4D42) { // BMP signature
+    Serial.println(F("File size: ")); 
+    Serial.println(read32(bmpFile));
+    (void)read32(bmpFile); // Read & ignore creator bytes
+    bmpImageoffset = read32(bmpFile); // Start of image data
+    Serial.print(F("Image Offset: ")); 
+    Serial.println(bmpImageoffset, DEC);
+
+    // Read DIB header
+    Serial.print(F("Header size: ")); 
+    Serial.println(read32(bmpFile));
+    bmpWidth  = read32(bmpFile);
+    bmpHeight = read32(bmpFile);
+
+    if(read16(bmpFile) == 1) { // # planes -- must be '1'
+      bmpDepth = read16(bmpFile); // bits per pixel
+      Serial.print(F("Bit Depth: ")); 
+      Serial.println(bmpDepth);
+      if((bmpDepth == 24) && (read32(bmpFile) == 0)) { // 0 = uncompressed
+        goodBmp = true; // Supported BMP format -- proceed!
+        Serial.print(F("Image size: "));
+        Serial.print(bmpWidth);
+        Serial.print('x');
+        Serial.println(bmpHeight);
+
+        // BMP rows are padded (if needed) to 4-byte boundary
+        rowSize = (bmpWidth * 3 + 3) & ~3;
+
+        // If bmpHeight is negative, image is in top-down order.
+        // This is not canon but has been observed in the wild.
+        if(bmpHeight < 0) {
+          bmpHeight = -bmpHeight;
+          flip      = false;
+        }
+
+        // Crop area to be loaded
+        w = bmpWidth;
+        h = bmpHeight;
+        if((x+w-1) >= tft.width())  w = tft.width()  - x;
+        if((y+h-1) >= tft.height()) h = tft.height() - y;
+
+        // Set TFT address window to clipped image bounds
+
+        for (row=0; row<h; row++) { // For each scanline...
+          // Seek to start of scan line.  It might seem labor-
+          // intensive to be doing this on every line, but this
+          // method covers a lot of gritty details like cropping
+          // and scanline padding.  Also, the seek only takes
+          // place if the file position actually needs to change
+          // (avoids a lot of cluster math in SD library).
+          if(flip) // Bitmap is stored bottom-to-top order (normal BMP)
+            pos = bmpImageoffset + (bmpHeight - 1 - row) * rowSize;
+          else     // Bitmap is stored top-to-bottom
+            pos = bmpImageoffset + row * rowSize;
+          
+          if(bmpFile.position() != pos) { // Need seek?
+            bmpFile.seek(pos);
+            buffidx = sizeof(sdbuffer); // Force buffer reload
+          }
+
+          for (col=0; col<w; col++) { // For each column...
+            // Time to read more pixel data?
+            if (buffidx >= sizeof(sdbuffer)) { // Indeed
+              // Push LCD buffer to the display first
+              if(lcdidx > 0) {
+                tft.drawPixels(lcdbuffer, lcdidx, col+x, row+y);
+                lcdidx = 0;
+                first  = false;
+              }
+
+              bmpFile.read(sdbuffer, sizeof(sdbuffer));
+              buffidx = 0; // Set index to beginning
+            }
+
+            // Convert pixel from BMP to TFT format
+            b = sdbuffer[buffidx++];
+            g = sdbuffer[buffidx++];
+            r = sdbuffer[buffidx++];
+            lcdbuffer[lcdidx++] = color565(r,g,b);
+            if (lcdidx >= sizeof(lcdbuffer)) {
+              tft.drawPixels(lcdbuffer, lcdidx, col+x, row+y);
+            }
+          } // end pixel
+            
+        } // end scanline
+
+        // Write any remaining data to LCD
+        if(lcdidx > 0) {
+          tft.drawPixels(lcdbuffer, lcdidx, col+x, row+y);
+        } 
+
+        Serial.print(F("Loaded in "));
+        Serial.print(millis() - startTime);
+        Serial.println(" ms");
+
+      } // end goodBmp
+    }
+  }
+
+  bmpFile.close();
+  if(!goodBmp) Serial.println(F("BMP format not recognized."));
+
+}
+
+// These read 16- and 32-bit types from the SD card file.
+// BMP data is stored little-endian, Arduino is little-endian too.
+// May need to reverse subscript order if porting elsewhere.
+
+uint16_t read16(File f) {
+  uint16_t result;
+  ((uint8_t *)&result)[0] = f.read(); // LSB
+  ((uint8_t *)&result)[1] = f.read(); // MSB
+  return result;
+}
+
+uint32_t read32(File f) {
+  uint32_t result;
+  ((uint8_t *)&result)[0] = f.read(); // LSB
+  ((uint8_t *)&result)[1] = f.read();
+  ((uint8_t *)&result)[2] = f.read();
+  ((uint8_t *)&result)[3] = f.read(); // MSB
+  return result;
+}
+
+uint16_t color565(uint8_t r, uint8_t g, uint8_t b) {
+  return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
+}
+
+byte decToBcd(byte val){
+  // Convert normal decimal numbers to binary coded decimal
+  return ( (val/10*16) + (val%10) );
+}


### PR DESCRIPTION
I added a new drawing function called drawPixels() which takes an array of pixels and outputs them to the display reducing any overhead. The format of the function was taken from the sumotoy/RA8875 which does not run on ESP32 processors and implemented in this library with the code formatting as close to other functions in here as possible.  According to my tests, using this function is about 4.3 times as fast as just using drawPixel().

I went ahead and modified the ra8875_bitmap example (called ra8875_bitmap_fast) to use this and ran both sketches. I compared the times shown in the serial monitor using the same image to determine the speed increase. Since this is quite a slow display, I thought this would be very useful. I included the modified example in the examples folder.

I'm not aware of any limitations of this function and since it is a new function it should not break any existing code.