### PR TITLE
Fix rect drawing width & height

### DIFF
--- a/Adafruit_RA8875.cpp
+++ b/Adafruit_RA8875.cpp
@@ -633,7 +633,7 @@ void Adafruit_RA8875::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t co
 /**************************************************************************/
 void Adafruit_RA8875::drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color)
 {
-  rectHelper(x, y, x+w, y+h, color, false);
+  rectHelper(x, y, x+w-1, y+h-1, color, false);
 }
 
 /**************************************************************************/
@@ -649,7 +649,7 @@ void Adafruit_RA8875::drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint1
 /**************************************************************************/
 void Adafruit_RA8875::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color)
 {
-  rectHelper(x, y, x+w, y+h, color, true);
+  rectHelper(x, y, x+w-1, y+h-1, color, true);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
### Scope of change
- **Fix**: `drawRect()`, `fillRect()`
- **Reason**: Existing implementation overdraws width and height by 1 pixel

### Limitations of change
- Like the original code, no additional bounds checking was added (eg. if users provides zero width or height)
