### PR TITLE
Added 480x128 Display Support

### DIFF
--- a/Adafruit_RA8875.cpp
+++ b/Adafruit_RA8875.cpp
@@ -78,7 +78,11 @@ Adafruit_RA8875::Adafruit_RA8875(uint8_t CS, uint8_t RST) : Adafruit_GFX(800, 48
 boolean Adafruit_RA8875::begin(enum RA8875sizes s) {
   _size = s;
 
-  if (_size == RA8875_480x272) {
+  if (_size == RA8875_480x128) {
+    _width = 480;
+    _height = 128;
+  }
+  else if (_size == RA8875_480x272) {
     _width = 480;
     _height = 272;
   }
@@ -158,7 +162,7 @@ void Adafruit_RA8875::softReset(void) {
 */
 /**************************************************************************/
 void Adafruit_RA8875::PLLinit(void) {
-  if (_size == RA8875_480x272) {
+  if (_size == RA8875_480x128 || _size == RA8875_480x272) {
     writeReg(RA8875_PLLC1, RA8875_PLLC1_PLLDIV1 + 10);
     delay(1);
     writeReg(RA8875_PLLC2, RA8875_PLLC2_DIV4);
@@ -192,7 +196,7 @@ void Adafruit_RA8875::initialize(void) {
   uint16_t vsync_start;
 
   /* Set the correct values for the display being used */
-  if (_size == RA8875_480x272)
+  if (_size == RA8875_480x128 || _size == RA8875_480x272)
   {
     pixclk          = RA8875_PCSR_PDATL | RA8875_PCSR_4CLK;
     hsync_nondisp   = 10;

--- a/Adafruit_RA8875.h
+++ b/Adafruit_RA8875.h
@@ -61,7 +61,7 @@
 #endif
 
 // Sizes!
-enum RA8875sizes { RA8875_480x272, RA8875_800x480 };
+enum RA8875sizes { RA8875_480x128, RA8875_480x272, RA8875_800x480 };
 
 // Touch screen cal structs
 typedef struct Point 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit RA8875
-version=1.0.8
+version=1.1.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Adafruit's Arduino driver for the RA8875 TFT driver


### PR DESCRIPTION
Fixes #11. As you thought, there it was the backlight PWM. Changing the value in the example made it less apparent, but the noise only happens for a second or so and I decided to leave it.