### PR TITLE
Optimization of drawPixels for MOAR speed

### DIFF
--- a/Adafruit_RA8875.cpp
+++ b/Adafruit_RA8875.cpp
@@ -695,9 +695,7 @@ void Adafruit_RA8875::drawPixels(uint16_t * p, uint32_t num, int16_t x, int16_t 
     digitalWrite(_cs, LOW);
     SPI.transfer(RA8875_DATAWRITE);
     while (num--) {
-        SPI.transfer(*p >> 8);
-        SPI.transfer(*p & 0xFF);
-        p++;
+        SPI.transfer16(*p++);
     }
     digitalWrite(_cs, HIGH);
 }


### PR DESCRIPTION
This was something I had been meaning to get around to for a while. Tested on the Metro328 with the bitmap_fast sketch.