### PR TITLE
Minor improvements

### DIFF
--- a/Adafruit_RA8875.cpp
+++ b/Adafruit_RA8875.cpp
@@ -503,8 +503,6 @@ void Adafruit_RA8875::cursorBlink(uint8_t rate) {
   temp |= RA8875_MWCR0_BLINK;
   writeData(temp);
 
-  if (rate > 255)
-    rate = 255;
   writeCommand(RA8875_BTCR);
   writeData(rate);
 }

--- a/Adafruit_RA8875.cpp
+++ b/Adafruit_RA8875.cpp
@@ -81,7 +81,8 @@ static inline void spi_end(void) { SPI.endTransaction(); }
 */
 /**************************************************************************/
 Adafruit_RA8875::Adafruit_RA8875(uint8_t CS, uint8_t RST)
-    : Adafruit_GFX(800, 480) {
+    : Adafruit_GFX(800, 480), _width(0), _height(0), _textScale(1),
+      _rotation(1), _voffset(0) {
   _cs = CS;
   _rst = RST;
 }

--- a/Adafruit_RA8875.h
+++ b/Adafruit_RA8875.h
@@ -138,6 +138,7 @@ typedef struct // Matrix
 /**************************************************************************/
 class Adafruit_RA8875 : public Adafruit_GFX {
 public:
+  Adafruit_RA8875() = delete;
   Adafruit_RA8875(uint8_t cs, uint8_t rst);
 
   boolean begin(enum RA8875sizes s);

--- a/Adafruit_RA8875.h
+++ b/Adafruit_RA8875.h
@@ -140,6 +140,7 @@ class Adafruit_RA8875 : public Adafruit_GFX {
 public:
   Adafruit_RA8875() = delete;
   Adafruit_RA8875(uint8_t cs, uint8_t rst);
+  virtual ~Adafruit_RA8875() = default;
 
   boolean begin(enum RA8875sizes s);
   void softReset(void);


### PR DESCRIPTION
- Delete default constructor, so that people don't accidentally default-construct an instance which will have garbage values for all members (including CS and RST pins)
- Implement virtual destructor (derived class). Actually, now that I think about it, `Adafruit_GFX` needs a virtual destructor as well. I'll submit a different PR for that
- Provide default initialization values for members which will remain uninitialized with garbage values until `begin()` is called (I found out the hard way when I tried to get width and height before calling `begin()`)
- Remove unnecessary if-statement (an unsigned 8-bit value cannot be greater than 255, so the capping is superfluous)